### PR TITLE
Travis check all proof

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ install:
 script:
   - eval $(opam config env)
   - opam config var root
-  - make -j ${NJOBS}
+  - make build -j ${NJOBS}

--- a/src/drf/DRF_PF.v
+++ b/src/drf/DRF_PF.v
@@ -147,7 +147,7 @@ Proof.
   s. pcofix CIH. i. pfold. econs.
   - i. esplits; eauto. inv PR. inv WF. rewrite THS. clear -TERMINAL_TGT.
     ii. rewrite IdentMap.Facts.map_o in FIND.
-    destruct (IdentMap.find tid x1.(Configuration.threads)) as [[]|] eqn:X; ss. inv FIND.
+    destruct (IdentMap.find tid x3.(Configuration.threads)) as [[]|] eqn:X; ss. inv FIND.
     exploit TERMINAL_TGT; eauto. i. des. esplits; ss.
   - hexploit sim_pf_has_promise; eauto. i.
     i. exploit sim_pf_step; eauto. i. des.

--- a/src/opt/Compatibility.v
+++ b/src/opt/Compatibility.v
@@ -481,7 +481,7 @@ Qed.
 Lemma sim_stmts_nil sim_regs:
   sim_stmts sim_regs [] [] sim_regs.
 Proof.
-  ii. pupto9_init. pupto9 ctx_weak_respectful.
+  ii. pupto9_init. pupto9 ctx_weak_respectful. auto.
 Qed.
 
 Lemma sim_stmts_seq

--- a/src/opt/ReorderLoad.v
+++ b/src/opt/ReorderLoad.v
@@ -276,7 +276,7 @@ Proof.
   pcofix CIH. i. pfold. ii. ss. splits; ss; ii.
   - inv TERMINAL_TGT. inv PR; ss.
   - exploit sim_load_mon; eauto. i. des.
-    exploit sim_load_future; try apply x8; eauto. i. des.
+    exploit sim_load_future; try apply x0; eauto. i. des.
     esplits; eauto.
   - esplits; eauto.
     inv PR. inv READ. inv LOCAL. ss.

--- a/src/opt/ReorderStore.v
+++ b/src/opt/ReorderStore.v
@@ -264,10 +264,10 @@ Proof.
   pcofix CIH. i. pfold. ii. ss. splits; ss; ii.
   - inv TERMINAL_TGT. inv PR; ss.
   - exploit sim_store_mon; eauto. i. des.
-    exploit sim_store_future; try apply x8; eauto. i. des.
+    exploit sim_store_future; try apply x0; eauto. i. des.
     esplits; eauto.
   - exploit sim_store_mon; eauto. i.
-    inversion x8. subst. i.
+    inversion x0. subst. i.
     exploit (progress_program_step rs i2 nil); eauto. i. des.
     destruct th2. exploit sim_store_step; eauto.
     { econs 2. eauto. }

--- a/src/opt/ReorderUpdate.v
+++ b/src/opt/ReorderUpdate.v
@@ -72,7 +72,7 @@ Inductive sim_update: forall (st_src:lang.(Language.state)) (lc_src:Local.t) (sc
     (RMW: RegFile.eval_rmw rs rmw1 vr1 = (vret1, vw1))
     (REORDER: reorder_update r1 l1 rmw1 or1 ow1 i2)
     (READ: Local.read_step lc1_src mem1_src l1 from1 vr1 releasedr1 or1 lc2_src)
-    (FULFILL: match vw1 with 
+    (FULFILL: match vw1 with
               | Some val => fulfill_step lc2_src sc1_src l1 from1 to1 val releasedr1 releasedw1 ow1 lc3_src sc3_src 
               | None => lc3_src = lc2_src /\ sc3_src = sc1_src
               end)
@@ -495,10 +495,10 @@ Proof.
   pcofix CIH. i. pfold. ii. ss. splits; ss; ii.
   - inv TERMINAL_TGT. inv PR; ss.
   - exploit sim_update_mon; eauto. i. des.
-    exploit sim_update_future; try apply x8; eauto. i. des.
+    exploit sim_update_future; try apply x0; eauto. i. des.
     esplits; eauto.
   - exploit sim_update_mon; eauto. i.
-    inversion x8. subst. i.
+    inversion x0. subst. i.
     exploit (progress_program_step (RegFun.add r1 (fst (RegFile.eval_rmw rs rmw1 vr1)) rs) i2 nil); eauto. i. des.
     destruct th2. exploit sim_update_step; eauto.
     { rewrite RMW in *. ss. econs 2. eauto. }

--- a/src/opt/SplitAcq.v
+++ b/src/opt/SplitAcq.v
@@ -317,7 +317,7 @@ Proof.
   pcofix CIH. i. pfold. ii. ss. splits; ss; ii.
   - inv TERMINAL_TGT. inv PR; ss.
   - exploit sim_acquired_mon; eauto. i. des.
-    exploit sim_acquired_future; try apply x8; eauto. i. des.
+    exploit sim_acquired_future; try apply x0; eauto. i. des.
     esplits; eauto.
   - esplits; eauto.
     inv PR. eapply sim_local_memory_bot; eauto.

--- a/src/opt/SplitAcqRel.v
+++ b/src/opt/SplitAcqRel.v
@@ -326,7 +326,7 @@ Proof.
   pcofix CIH. i. pfold. ii. ss. splits; ss; ii.
   - inv TERMINAL_TGT. inv PR; ss.
   - exploit sim_acqrel_mon; eauto. i. des.
-    exploit sim_acqrel_future; try apply x8; eauto. i. des.
+    exploit sim_acqrel_future; try apply x0; eauto. i. des.
     esplits; eauto.
   - esplits; eauto.
     inv PR. eapply sim_local_memory_bot; eauto.

--- a/src/opt/SplitRel.v
+++ b/src/opt/SplitRel.v
@@ -294,7 +294,7 @@ Proof.
   pcofix CIH. i. pfold. ii. ss. splits; ss; ii.
   - inv TERMINAL_TGT. inv PR; ss.
   - exploit sim_released_mon; eauto. i. des.
-    exploit sim_released_future; try apply x8; eauto. i. des.
+    exploit sim_released_future; try apply x0; eauto. i. des.
     esplits; eauto.
   - esplits; eauto.
     inv PR. eapply sim_local_memory_bot; eauto.


### PR DESCRIPTION
Since travis in #9 doesn't check the proof (it uses `make` rather than `make build`), #9 contains some compile errors. 
I updated `.travis.yml` and fixed the proof.